### PR TITLE
Add LangGraph chatbot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,14 @@ Run it with:
 python chat.py
 ```
 
+## LangGraph demo
+
+An alternative implementation using [LangGraph](https://github.com/langchain-ai/langgraph) is provided.
+Run it with:
+
+```bash
+python langgraph_chat.py
+```
+
 Type messages in Japanese. When the bot detects low confidence or keywords,
 it prompts for a human operator response.

--- a/langgraph_chat.py
+++ b/langgraph_chat.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any
+
+from bot import BotService
+from handoff import HandoffService
+from operator_service import OperatorService
+from langgraph.graph import Graph, END
+
+
+def main() -> None:
+    bot = BotService()
+    handoff = HandoffService()
+    operator = OperatorService()
+
+    def bot_node(data: dict[str, str]) -> dict[str, Any]:
+        message = data["message"]
+        response, confidence = bot.generate_response(message)
+        return {"message": message, "response": response, "confidence": confidence}
+
+    def needs_operator(data: dict[str, Any]) -> bool:
+        return handoff.needs_handoff(data["message"], float(data["confidence"]))
+
+    def operator_node(data: dict[str, Any]) -> dict[str, str]:
+        reply = operator.handle_message(data["message"])
+        return {"final": f"オペレーター: {reply}"}
+
+    def output_node(data: dict[str, Any]) -> dict[str, str]:
+        return {"final": f"Bot({data['confidence']:.1f}): {data['response']}"}
+
+    workflow = Graph()
+    workflow.add_node("bot", bot_node)
+    workflow.add_node("operator", operator_node)
+    workflow.add_node("output", output_node)
+    workflow.set_entry_point("bot")
+    workflow.add_conditional_edges("bot", needs_operator, path_map={True: "operator", False: "output"})
+    workflow.add_edge("operator", END)
+    workflow.add_edge("output", END)
+
+    app = workflow.compile()
+
+    print("LangGraph チャットを開始します。終了するには 'exit' を入力してください。")
+    while True:
+        user_message = input("あなた: ")
+        if user_message.strip().lower() == "exit":
+            print("終了します。")
+            break
+        result = app.invoke({"message": user_message})
+        print(result["final"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple `langgraph_chat.py` example that uses LangGraph to route between bot and operator
- document how to run the new LangGraph demo

## Testing
- `ruff check .`
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_684f8230a9808326ad5a4b52d91cb604